### PR TITLE
[BEAM-1726] Fix empty side inputs in Flink Streaming Runner

### DIFF
--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/SideInputHandler.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/SideInputHandler.java
@@ -19,6 +19,7 @@ package org.apache.beam.runners.core;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -163,11 +164,6 @@ public class SideInputHandler implements ReadyCheckingSideInputReader {
   @Override
   public <T> T get(PCollectionView<T> sideInput, BoundedWindow window) {
 
-    if (!isReady(sideInput, window)) {
-      throw new IllegalStateException(
-          "Side input " + sideInput + " is not ready for window " + window);
-    }
-
     @SuppressWarnings("unchecked")
     Coder<BoundedWindow> windowCoder =
         (Coder<BoundedWindow>) sideInput
@@ -182,6 +178,10 @@ public class SideInputHandler implements ReadyCheckingSideInputReader {
         stateInternals.state(StateNamespaces.window(windowCoder, window), stateTag);
 
     Iterable<WindowedValue<?>> elements = state.read();
+
+    if (elements == null) {
+      elements = Collections.emptyList();
+    }
 
     return sideInput.getViewFn().apply(elements);
   }

--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/FlinkRunnerResult.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/FlinkRunnerResult.java
@@ -17,8 +17,9 @@
  */
 package org.apache.beam.runners.flink;
 
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableList;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import org.apache.beam.sdk.AggregatorRetrievalException;
@@ -64,8 +65,13 @@ public class FlinkRunnerResult implements PipelineResult {
     final T value = (T) aggregators.get(name);
     if (value != null) {
       return new AggregatorValues<T>() {
+        @Override
+        public Collection<T> getValues() {
+          return ImmutableList.of(value);
+        }
+
         @Override public Map<String, T> getValuesAtSteps() {
-          return ImmutableMap.of("all", value);
+          throw new UnsupportedOperationException("getValuesAtSteps is not supported.");
         }
       };
     } else {

--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/TestFlinkRunner.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/TestFlinkRunner.java
@@ -110,7 +110,7 @@ public class TestFlinkRunner extends PipelineRunner<PipelineResult> {
     try {
       AggregatorValues<Integer> succeededAssertionsValues = result
           .getAggregatorValues(PAssert.SUCCESS_COUNTER);
-      succeededAssertions = succeededAssertionsValues.getValuesAtSteps().values();
+      succeededAssertions = succeededAssertionsValues.getValues();
     } catch (AggregatorRetrievalException e) {
       // No assertions registered will cause an AggregatorRetrievalException here.
     }
@@ -118,7 +118,7 @@ public class TestFlinkRunner extends PipelineRunner<PipelineResult> {
     try {
       AggregatorValues<Integer> failedAssertionsValues = result
           .getAggregatorValues(PAssert.FAILURE_COUNTER);
-      failedAssertions = failedAssertionsValues.getValuesAtSteps().values();
+      failedAssertions = failedAssertionsValues.getValues();
     } catch (AggregatorRetrievalException e) {
       // No assertions registered will cause an AggregatorRetrievalException here.
     }

--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
@@ -479,7 +479,32 @@ public class DoFnOperator<InputT, FnOutputT, OutputT>
 
   @Override
   public void processWatermark2(Watermark mark) throws Exception {
-    // ignore watermarks from the side-input input
+    if (mark.getTimestamp() == BoundedWindow.TIMESTAMP_MAX_VALUE.getMillis()) {
+      // this means we will never see any more side input
+      pushbackDoFnRunner.startBundle();
+
+      BagState<WindowedValue<InputT>> pushedBack =
+          pushbackStateInternals.state(StateNamespaces.global(), pushedBackTag);
+
+      Iterable<WindowedValue<InputT>> pushedBackContents = pushedBack.read();
+      if (pushedBackContents != null) {
+        for (WindowedValue<InputT> elem : pushedBackContents) {
+
+          // we need to set the correct key in case the operator is
+          // a (keyed) window operator
+          setKeyContextElement1(new StreamRecord<>(elem));
+
+          pushbackDoFnRunner.processElement(elem);
+        }
+      }
+
+      setPushedBackWatermark(BoundedWindow.TIMESTAMP_MAX_VALUE.getMillis());
+
+      pushbackDoFnRunner.finishBundle();
+
+      // maybe output a new watermark
+      processWatermark1(new Watermark(currentInputWatermark));
+    }
   }
 
   @Override


### PR DESCRIPTION
This fixes some tests but surfaces a new problem: `ViewTest.testNonSingletonSideInput()` now fails because we don't wrap/unwrap a thrown exception the right way.